### PR TITLE
v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ To learn more about the technologies used, refer to their respective documentati
 
 ## 🚩 TODO
 
-- [ ] Improve documentation
+- [ ] Improve documentation: Was thinking to use [nextra](https://github.com/shuding/nextra-docs-template)
 
 ## 🚀 Deploy on Vercel
 

--- a/src/components/utils/Meta.tsx
+++ b/src/components/utils/Meta.tsx
@@ -4,14 +4,13 @@ type MetaProps = {
   title?: string;
   description?: string;
   image?: string;
-  nested?: boolean;
 };
 
 const titleGenerator = (title?: string) => {
   return title ? `${title} | Next Power Starter` : "Next Power Starter";
 };
 
-const Meta = ({ title, description, image, nested = false }: MetaProps) => {
+const Meta = ({ title, description, image }: MetaProps) => {
   return (
     <Head>
       <title>{titleGenerator(title)}</title>
@@ -29,14 +28,9 @@ const Meta = ({ title, description, image, nested = false }: MetaProps) => {
         </>
       )}
 
-      {/* Don't feel like jamming up the header */}
-      {nested && (
-        <>
-          <meta property="og:type" content="website" />
-          <meta property="twitter:card" content="summary_large_image" />
-          <link rel="icon" href="/favicon.ico" />
-        </>
-      )}
+      <meta property="og:type" content="website" />
+      <meta property="twitter:card" content="summary_large_image" />
+      <link rel="icon" href="/favicon.ico" />
 
       <meta property="og:title" content={titleGenerator(title)} />
       <meta property="twitter:title" content={titleGenerator(title)} />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,7 @@ export type NextPageWithAttributes<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => JSX.Element;
   isPublic?: boolean;
   title?: string;
+  customHeader?: boolean;
 };
 
 type AppPropsWithAttributes = AppProps & {
@@ -20,11 +21,13 @@ type AppPropsWithAttributes = AppProps & {
 export default function App({ Component, pageProps }: AppPropsWithAttributes) {
   return (
     <>
-      <Meta
-        title={Component.title}
-        description="A powerful zap starter template with simplicity and flexibility in mind"
-        image="https://user-images.githubusercontent.com/55322546/256514847-e21721f5-bb92-49e0-9d2d-23dc7f98f30d.png"
-      />
+      {!Component.customHeader && (
+        <Meta
+          title={Component.title}
+          description="A powerful Next starter template with simplicity and flexibility in mind"
+          image="https://user-images.githubusercontent.com/55322546/256514847-e21721f5-bb92-49e0-9d2d-23dc7f98f30d.png"
+        />
+      )}
       <Provider>
         <AuthGuard Component={Component} pageProps={pageProps} />
       </Provider>


### PR DESCRIPTION
- Added `customHeader` page property so that the <Meta> will not be included for page that requires custom header to avoid duplicating Meta tags